### PR TITLE
[HCFRO-409] - cf-plugin-backup version should come from git --describe

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/hpcloud/cf-plugin-backup",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v72",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -62,8 +62,8 @@
 		},
 		{
 			"ImportPath": "github.com/blang/semver",
-			"Comment": "v3.1.0",
-			"Rev": "aea32c919a18e5ef4537bbd283ff29594b1b0165"
+			"Comment": "v3.3.0",
+			"Rev": "60ec3488bfea7cca02b021d106d9911120d25fe9"
 		},
 		{
 			"ImportPath": "github.com/cheggaaa/pb",

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"runtime/debug"
 
+	"github.com/blang/semver"
+
 	"github.com/hpcloud/termui"
 	"github.com/hpcloud/termui/termpassword"
 
@@ -16,7 +18,7 @@ import (
 )
 
 var target string
-
+var version string 
 //BackupPlugin represents the struct of the cf cli plugin
 type BackupPlugin struct {
 	cliConnection plugin.CliConnection
@@ -75,12 +77,18 @@ func (c *BackupPlugin) GetMetadata() plugin.PluginMetadata {
 	for _, value := range helpMessages {
 		summary = fmt.Sprintf("%s \n %s ", summary, value)
 	}
+	pluginVersion, err := semver.ParseTolerant(version)
+
+	if err != nil {
+        	panic(fmt.Sprintf("Invalid plugin version %s: %s", version, err))
+    	}
+
 	return plugin.PluginMetadata{
 		Name: "Backup",
 		Version: plugin.VersionType{
-			Major: 1,
-			Minor: 0,
-			Build: 0,
+			Major: int(pluginVersion.Major),
+			Minor: int(pluginVersion.Minor),
+			Build: int(pluginVersion.Patch),
 		},
 		MinCliVersion: plugin.VersionType{
 			Major: 1,

--- a/make/build
+++ b/make/build
@@ -11,13 +11,13 @@ echo "${OK_COLOR}==> Building ${ERROR_COLOR}"
 
 for OS in ${OSES}; do \
 		 env GOOS=${OS} GOARCH=amd64 go build -o build/${OS}-amd64/cf-plugin-backup \
-		 -ldflags="-X main.version=${APP_VERSION}" \
+		 -ldflags="-X main.version=${ARTIFACT_VERSION}" \
 		 ./  
 done
 
 #windows is special
 env GOOS=windows GOARCH=amd64 go build -o build/windows-amd64/cf-plugin-backup.exe \
--ldflags="-X main.version=${APP_VERSION}" \
+-ldflags="-X main.version=${ARTIFACT_VERSION}" \
 ./
 
 echo "${NO_COLOR}\c"

--- a/make/include/versioning.sh
+++ b/make/include/versioning.sh
@@ -15,7 +15,13 @@ GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $2 }' )}
 GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $3 }' )}
 
 ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^hcf-//)}
-ARTIFACT_VERSION=${GIT_TAG}+${GIT_COMMITS}.${GIT_SHA}.${GIT_BRANCH}
+#if we don't have a release don't add GIT_COMMITS and GIT_SHA in the version
+if [ -z "${GIT_COMMITS}" ] && [ -z "${GIT_SHA}" ] 
+    then
+        ARTIFACT_VERSION="1.0.0"+${GIT_TAG}.${GIT_BRANCH}
+    else
+        ARTIFACT_VERSION=${GIT_TAG}+${GIT_COMMITS}.${GIT_SHA}.${GIT_BRANCH}
+fi
 
 APP_VERSION=${ARTIFACT_NAME}-${ARTIFACT_VERSION}
 

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -222,3 +222,12 @@ func parseComparator(s string) comparator {
 
 	return nil
 }
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -200,6 +200,29 @@ func Make(s string) (Version, error) {
 	return Parse(s)
 }
 
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
+// with only major and minor components specified
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+		s = strings.Join(parts, ".")
+	}
+
+	return Parse(s)
+}
+
 // Parse parses version string and returns a validated Version or error
 func Parse(s string) (Version, error) {
 	if len(s) == 0 {


### PR DESCRIPTION
Now as long as the git tag follows the **Major.Minor.Patch**  pattern, this version will be visible on the build.
The semver package was also updated to the last version so that we can use ParseTolerant.
