### PR TITLE
Add proper tar build dir, remove owner/group names

### DIFF
--- a/make/dist
+++ b/make/dist
@@ -7,8 +7,10 @@ set -o errexit
 . make/include/colors.sh
 . make/include/versioning.sh
 
-
 echo "${OK_COLOR}==> Disting all${NO_COLOR}"; \
 for OS in ${OSES}; do \
-	cd build/${OS}-amd64/ 1> /dev/null; tar czf ../../${APP_VERSION}-${OS}-amd64.tgz ./; cd - 1> /dev/null; \
+  rm -rf build/cf-plugin-backup
+  mkdir build/cf-plugin-backup
+  cp build/${OS}-amd64/* build/cf-plugin-backup/
+  tar czf ${APP_VERSION}.${OS}-amd64.tgz --owner=0 --group=0 --numeric-owner -C build cf-plugin-backup
 done; 


### PR DESCRIPTION
- Remove the branch name from versioning like hcf has done, it's not
  important since we have the git hash.
