### PR TITLE
Fix error behaviour when the snapshot file does not exist.

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -23,7 +23,7 @@ It includes a summary of organizations, spaces and apps
 	Run: func(cmd *cobra.Command, args []string) {
 		backupJSON, err := ioutil.ReadFile(backupFile)
 		if os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Failed to read backup information file %s.\n", backupFile)
+			fmt.Fprintf(os.Stdout, "Failed to read backup information file %s.\nYou can create one with `backup-snapshot`.\n", backupFile)
 			os.Exit(1)
 		}
 		util.FreakOut(err)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -466,11 +466,11 @@ func restoreFromJSON(includeSecurityGroups bool, includeQuotaDefinitions bool) {
 	//map["old_guid"] = "new_guid"
 	spaceGuids := make(map[string]string)
 
-	var fileContent []byte
-	_, err := os.Stat(backupFile)
-	util.FreakOut(err)
-
-	fileContent, err = ioutil.ReadFile(backupFile)
+	fileContent, err := ioutil.ReadFile(backupFile)
+	if os.IsNotExist(err) {
+		fmt.Fprintf(os.Stdout, "Failed to read backup information file %s.\nYou can create one with `backup-snapshot`.\n", backupFile)
+		os.Exit(1)
+	}
 	util.FreakOut(err)
 
 	backupObject, err := util.ReadBackupJSON(fileContent)

--- a/make/clean
+++ b/make/clean
@@ -1,5 +1,13 @@
+#!/bin/sh
+
 set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
+. make/include/colors.sh
+
+printf "%b==> Cleaning %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 rm -rf ${GIT_ROOT}/build
+
+printf "%b" "${NO_COLOR}"


### PR DESCRIPTION
- make: Have the `clean` script announce itself, as all the others do.
- general: print to stdout, stderr looks to be swallowed and lost.
- cmd/info: Extend message with reference to the `snapshot` command.
- cmd/restore: Removed superflous stat call, added same handling for `file-does-not-exist` as done by the `info` command.

https://trello.com/c/oaOsLRL6/623-backup-cli-clearer-error-for-cf-backup-snapshot-is-required-for-cf-backup-restore