### PR TITLE
Add a check on the metadata type conversion

### DIFF
--- a/util/cc_helpers.go
+++ b/util/cc_helpers.go
@@ -305,7 +305,12 @@ func (ccResources *CCResources) transformToResourceModel(resource interface{}) *
 
 	resourceValue := resource.(map[string]interface{})
 
-	resourceModel.Metadata = resourceValue["metadata"].(map[string]interface{})
+	metadata, hasMetadata := resourceValue["metadata"].(map[string]interface{})
+	if hasMetadata {
+		resourceModel.Metadata = metadata
+	} else {
+		return &resourceModel
+	}
 	entity, hasEntity := resourceValue["entity"].(map[string]interface{})
 
 	// Cache handling


### PR DESCRIPTION
When using the plugin in a live env.  You can because of the time it takes to retrieve things get failed gets on some resources.  This causes empty resources.   Putting the validation here to make sure you are not working on an empty resource solves the problem.

I could not really figure a way to add this into a unit test so unfortunately it's as is.

Let me know if you can think of a way to unit test this.